### PR TITLE
Maintenance: Code Quality Review - 2026-06-03

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -665,7 +665,7 @@ fn compute_network_rates(metrics: &[MetricSample]) -> Vec<NetworkRateSample> {
 
     let mut rates = Vec::new();
     for (_iface, mut samples) in by_iface {
-        samples.sort_by(|a, b| a.ts.partial_cmp(&b.ts).unwrap());
+        samples.sort_by(|a, b| a.ts.partial_cmp(&b.ts).unwrap_or(std::cmp::Ordering::Equal));
         for window in samples.windows(2) {
             let prev = window[0];
             let next = window[1];
@@ -713,7 +713,7 @@ fn bucket_network_totals(
 
     let mut buckets: BTreeMap<DateTime<Local>, TransferStats> = BTreeMap::new();
     for (_iface, mut samples) in by_iface {
-        samples.sort_by(|a, b| a.ts.partial_cmp(&b.ts).unwrap());
+        samples.sort_by(|a, b| a.ts.partial_cmp(&b.ts).unwrap_or(std::cmp::Ordering::Equal));
         for window in samples.windows(2) {
             let prev = window[0];
             let next = window[1];

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -367,7 +367,7 @@ fn network_bucket_series(
     // Collect all deltas with timestamps across all interfaces
     let mut all_deltas = Vec::new();
     for (_iface, mut samples) in by_iface {
-        samples.sort_by(|a, b| a.ts.partial_cmp(&b.ts).unwrap());
+        samples.sort_by(|a, b| a.ts.partial_cmp(&b.ts).unwrap_or(std::cmp::Ordering::Equal));
 
         for window in samples.windows(2) {
             let prev = window[0];
@@ -397,11 +397,11 @@ fn network_bucket_series(
         all_deltas
             .iter()
             .map(|(ts, _, _)| ts)
-            .min_by(|a, b| a.partial_cmp(b).unwrap()),
+            .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)),
         all_deltas
             .iter()
             .map(|(ts, _, _)| ts)
-            .max_by(|a, b| a.partial_cmp(b).unwrap()),
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)),
     ) {
         Some(last - first)
     } else {


### PR DESCRIPTION
## Code Quality Improvements

### Changes Made
- **Fixed potential panics in float comparisons**: Replaced unwrap() calls on partial_cmp() results with unwrap_or() to handle NaN values gracefully
- Affected files: src/cli.rs, src/graph.rs

### Rationale
Float comparisons using partial_cmp() can return None when comparing NaN values. Using unwrap() on these results causes panics. The fix uses unwrap_or(Ordering::Equal) to safely handle edge cases without crashing.

### Impact
- 5 panic-prone code paths now handle NaN values gracefully
- Improved robustness in sorting and min/max operations on timestamps